### PR TITLE
Safari/iOS fix

### DIFF
--- a/addon/mixins/in-viewport.js
+++ b/addon/mixins/in-viewport.js
@@ -130,6 +130,7 @@ export default Mixin.create({
       });
     } else {
       return scheduleOnce('afterRender', this, () => {
+        this.get('_rAFAdmin').restart();
         this._setViewportEntered();
       });
     }

--- a/addon/services/-raf-admin.js
+++ b/addon/services/-raf-admin.js
@@ -30,6 +30,13 @@ export default class RAFAdmin extends Service {
     });
   }
 
+  restart() {
+    if (!this.isRunning) {
+      this.isRunning = true;
+      this.flush();
+    }
+  }
+
   add(elementId, fn) {
     this.pool.push({ [elementId]: fn });
     return fn;


### PR DESCRIPTION
rAF service is now capable of restarting in case of an element change without reinitializing the service
